### PR TITLE
fixed flakiness in JacksonXmlHandlerTest.java

### DIFF
--- a/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
@@ -32,20 +32,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JacksonXmlHandlerTest extends XWorkTestCase {
 
-    private String xml;
+    private String xml, prefix, suffix, name, age, parents;
     private JacksonXmlHandler handler;
     private ActionInvocation ai;
 
     public void setUp() throws Exception {
         super.setUp();
-        xml = "<SimpleBean>" +
-                "<name>Jan</name>" +
-                "<age>12</age>" +
-                "<parents>" +
-                "<parents>Adam</parents>" +
-                "<parents>Ewa</parents>" +
-                "</parents>" +
-                "</SimpleBean>";
+        name = "<name>Jan</name>";
+        age = "<age>12</age>";
+        parents = "<parents>" +
+                            "<parents>Adam</parents>" +
+                            "<parents>Ewa</parents>" +
+                            "</parents>";  
+        prefix = "<SimpleBean>";
+        suffix = "</SimpleBean>";
+        xml = prefix + name + age + parents + suffix;
+
         handler = new JacksonXmlHandler();
         ai = new MockActionInvocation();
     }
@@ -60,10 +62,16 @@ public class JacksonXmlHandlerTest extends XWorkTestCase {
         // when
         Writer stream = new StringWriter();
         handler.fromObject(ai, obj, null, stream);
+        String actual = stream.toString();
 
         // then
         stream.flush();
-        assertEquals(xml, stream.toString());
+        assertTrue(actual.length()==xml.length()&&
+            actual.contains(prefix)&&
+            actual.contains(suffix)&&
+            actual.contains(name)&&
+            actualcontains(age)&&
+            actual.contains(parents));
     }
 
     public void testXmlToObject() throws Exception {

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
@@ -67,10 +67,11 @@ public class JacksonXmlHandlerTest extends XWorkTestCase {
         // then
         stream.flush();
         assertTrue(actual.length() == xml.length() &&
-            actual.startsWith(suffix) &&
+            actual.startsWith(prefix) &&
             actual.contains(name) &&
             actual.contains(age) &&
-            actual.endsWith(parents));
+            actual.contains(parents) &&
+            actual.endsWith(suffix));
     }
 
     public void testXmlToObject() throws Exception {

--- a/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
+++ b/plugins/rest/src/test/java/org/apache/struts2/rest/handler/JacksonXmlHandlerTest.java
@@ -41,9 +41,9 @@ public class JacksonXmlHandlerTest extends XWorkTestCase {
         name = "<name>Jan</name>";
         age = "<age>12</age>";
         parents = "<parents>" +
-                            "<parents>Adam</parents>" +
-                            "<parents>Ewa</parents>" +
-                            "</parents>";  
+                    "<parents>Adam</parents>" +
+                    "<parents>Ewa</parents>" +
+                    "</parents>";  
         prefix = "<SimpleBean>";
         suffix = "</SimpleBean>";
         xml = prefix + name + age + parents + suffix;
@@ -66,12 +66,11 @@ public class JacksonXmlHandlerTest extends XWorkTestCase {
 
         // then
         stream.flush();
-        assertTrue(actual.length()==xml.length()&&
-            actual.contains(prefix)&&
-            actual.contains(suffix)&&
-            actual.contains(name)&&
-            actualcontains(age)&&
-            actual.contains(parents));
+        assertTrue(actual.length() == xml.length() &&
+            actual.startsWith(suffix) &&
+            actual.contains(name) &&
+            actual.contains(age) &&
+            actual.endsWith(parents));
     }
 
     public void testXmlToObject() throws Exception {


### PR DESCRIPTION
Hi,

By running the following command:
`mvn -pl plugins/rest/ edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.struts2.rest.handler.JacksonXmlHandlerTest `,

`testObjectToXml` method will fail sometimes. This is because `fromObject()` method of `JacksonXmlHandler `uses `com.fasterxml.jackson.dataformat.xml.XmlMapper`, whose marshal strategy that serializes the object is non-deterministic. Thus, the output of `toString()` method of the serialized xml object is non-deterministic. I fixed the bug by checking the output contains all components of the xml object and the expected length. 